### PR TITLE
Performance optimization when nvram is empty

### DIFF
--- a/config.h
+++ b/config.h
@@ -21,6 +21,7 @@
 #define MOUNT_POINT         "/firmadyne/libnvram/"
 // Location of NVRAM override values that are copied into the base NVRAM implementation.
 #define OVERRIDE_POINT      "/firmadyne/libnvram.override/"
+#define EMPTY_PATH         MOUNT_POINT ".empty"
 
 // Define the semantics for success and failure error codes.
 #define E_FAILURE  0


### PR DESCRIPTION
I see long/slow patterns where applications are clearing their NVRAM entires one value at a time. e.g., Linksys `EAP330_EU_US_V2_170711.zip`.

This might help in some cases, but it doesn't help with my test - the nvram _isn't_ empty while tons of keys are cleared.