### PR TITLE
Add x86_64 support

### DIFF
--- a/hypercall.h
+++ b/hypercall.h
@@ -7,7 +7,7 @@ static inline void igloo_hypercall(unsigned long num, unsigned long arg1) {
        "movz $0, $0, $0"
         : "+r"(reg0)
         : "r"(reg1) // num in register v0
-        : // No clobber
+        : "memory"
     );
 
 
@@ -18,7 +18,7 @@ static inline void igloo_hypercall(unsigned long num, unsigned long arg1) {
             "msr S0_0_c5_c0_0, xzr \n"
             : "+r"(reg1)
             : "r"(reg0)
-            : // No clobber
+            : "memory"
         );
 #elif defined(CONFIG_ARM) 
     register unsigned long reg0 asm("r7") = num;
@@ -28,7 +28,7 @@ static inline void igloo_hypercall(unsigned long num, unsigned long arg1) {
     "mcr p7, 0, r0, c0, c0, 0"
       : "+r"(reg1)
       : "r"(reg0)
-      :
+      : "memory"
   );  
 #elif defined(CONFIG_X86_64)
     register unsigned long reg0 asm("rax") = num;
@@ -38,7 +38,7 @@ static inline void igloo_hypercall(unsigned long num, unsigned long arg1) {
         "cpuid"
         : "+r"(reg0)           // hypercall num + return value in rax
         : "r"(reg1)            // arguments
-        : // No clobber
+        : "memory"
     );
 #else
 #error "No igloo_hypercall support for architecture"
@@ -54,7 +54,7 @@ static inline unsigned long igloo_hypercall2(unsigned long num, unsigned long ar
        "msr S0_0_c5_c0_0, xzr \n"
         : "+r"(reg1)  // Input and output
         : "r"(reg0), "r"(reg2)
-        : // No clobber
+        : "memory"
     );
     return reg1;
 #elif defined(CONFIG_ARM)
@@ -66,10 +66,8 @@ static inline unsigned long igloo_hypercall2(unsigned long num, unsigned long ar
        "mcr p7, 0, r0, c0, c0, 0"
         : "+r"(reg1)  // Input and output
         : "r"(reg0), "r"(reg2)
-        : // No clobber
+        : "memory"
     );
-
-
 
     return reg1;
 
@@ -82,7 +80,7 @@ static inline unsigned long igloo_hypercall2(unsigned long num, unsigned long ar
        "movz $0, $0, $0"
         : "+r"(reg0)  // Input and output in R0
         : "r"(reg1) , "r" (reg2)// arg2 in register A1
-        : // No clobber
+        : "memory"
     );
     return reg0;
 #elif defined(CONFIG_X86_64)
@@ -94,7 +92,7 @@ static inline unsigned long igloo_hypercall2(unsigned long num, unsigned long ar
         "cpuid"
         : "+r"(reg0)           // hypercall num + return value in rax
         : "r"(reg1), "r"(reg2) // arguments
-        : // No clobber
+        : "memory"
     );
 
     return reg0;

--- a/hypercall.h
+++ b/hypercall.h
@@ -1,85 +1,104 @@
 static inline void igloo_hypercall(unsigned long num, unsigned long arg1) {
 #if defined(CONFIG_MIPS)
-    register unsigned long v0 asm("v0") = num;
-    register unsigned long a0 asm("a0") = arg1;
+    register unsigned long reg0 asm("v0") = num;
+    register unsigned long reg1 asm("a0") = arg1;
 
     asm volatile(
        "movz $0, $0, $0"
-        : "+r"(v0)
-        : "r"(a0) 
-        : "memory"
+        : "+r"(reg0)
+        : "r"(reg1) // num in register v0
+        : // No clobber
     );
+
 
 #elif defined(CONFIG_AARCH64)
-    register unsigned long long x8 asm("x8") = num;
-    register unsigned long long x0 asm("x0") = arg1;
+    register unsigned long reg0 asm("x8") = num;
+    register unsigned long reg1 asm("x0") = arg1;
+    asm volatile(
+            "msr S0_0_c5_c0_0, xzr \n"
+            : "+r"(reg1)
+            : "r"(reg0)
+            : // No clobber
+        );
+#elif defined(CONFIG_ARM) 
+    register unsigned long reg0 asm("r7") = num;
+    register unsigned long reg1 asm("r0") = arg1;
 
     asm volatile(
-        "mov x8, %0 \t\n\
-        mov x0, %1 \t\n\
-        msr S0_0_c5_c0_0, xzr"
-        :
-        : "r"(x8), "r"(x0)
-        : "memory"
-    );
-#elif defined(CONFIG_ARM)
-  register uint32_t r7 asm("r7") = num;
-  register uint32_t r0 asm("r0") = arg1;
-  asm volatile(
-     "mov r7, %0 \t\n\
-      mov r0, %1 \t\n\
-      mcr p7, 0, r0, c0, c0, 0"
+    "mcr p7, 0, r0, c0, c0, 0"
+      : "+r"(reg1)
+      : "r"(reg0)
       :
-      : "r"(r7), "r"(r0)
-      : "memory"
-  );
+  );  
+#elif defined(CONFIG_X86_64)
+    register unsigned long reg0 asm("rax") = num;
+    register unsigned long reg1 asm("rdi") = arg1;
+
+    asm volatile(
+        "cpuid"
+        : "+r"(reg0)           // hypercall num + return value in rax
+        : "r"(reg1)            // arguments
+        : // No clobber
+    );
 #else
 #error "No igloo_hypercall support for architecture"
 #endif
 }
 
 static inline unsigned long igloo_hypercall2(unsigned long num, unsigned long arg1, unsigned long arg2) {
-#if defined(CONFIG_ARM)
-    register unsigned long r7 asm("r7") = num;
-    register unsigned long r0 asm("r0") = arg1;
-    register unsigned long r1 asm("r1") = arg2;
+#if defined(CONFIG_AARCH64)
+    register unsigned long reg0 asm("x8") = num;
+    register unsigned long reg1 asm("x0") = arg1;
+    register unsigned long reg2 asm("x1") = arg2;
+    asm volatile(
+       "msr S0_0_c5_c0_0, xzr \n"
+        : "+r"(reg1)  // Input and output
+        : "r"(reg0), "r"(reg2)
+        : // No clobber
+    );
+    return reg1;
+#elif defined(CONFIG_ARM)
+    register unsigned long reg0 asm("r7") = num;
+    register unsigned long reg1 asm("r0") = arg1;
+    register unsigned long reg2 asm("r1") = arg2;
 
     asm volatile(
        "mcr p7, 0, r0, c0, c0, 0"
-        : "+r"(r0)  // Input and output
-        : "r"(r7), "r"(r1)
-        : "memory"
+        : "+r"(reg1)  // Input and output
+        : "r"(reg0), "r"(reg2)
+        : // No clobber
     );
 
-    return r0;
-#elif defined(CONFIG_AARCH64)
-    register unsigned long long x8 asm("x8") = num;
-    register unsigned long long x0 asm("x0") = arg1;
-    register unsigned long long x1 asm("x1") = arg2;
 
-    asm volatile(
-       "msr S0_0_c5_c0_0, xzr"
-        : "+r"(x0)
-        : "r"(x8), "r"(x1)
-        : "memory"
-    );
 
-    return x0;
+    return reg1;
+
 #elif defined(CONFIG_MIPS)
-    register unsigned long v0 asm("v0") = num;
-    register unsigned long a0 asm("a0") = arg1;
-    register unsigned long a1 asm("a1") = arg2;
+    register unsigned long reg0 asm("v0") = num;
+    register unsigned long reg1 asm("a0") = arg1;
+    register unsigned long reg2 asm("a1") = arg2;
 
     asm volatile(
        "movz $0, $0, $0"
-        : "+r"(v0) 
-        : "r"(a0) , "r" (a1)
-        : "memory"
+        : "+r"(reg0)  // Input and output in R0
+        : "r"(reg1) , "r" (reg2)// arg2 in register A1
+        : // No clobber
     );
-    return v0;
+    return reg0;
+#elif defined(CONFIG_X86_64)
+    register unsigned long reg0 asm("rax") = num;
+    register unsigned long reg1 asm("rdi") = arg1;
+    register unsigned long reg2 asm("rsi") = arg2;
 
+    asm volatile(
+        "cpuid"
+        : "+r"(reg0)           // hypercall num + return value in rax
+        : "r"(reg1), "r"(reg2) // arguments
+        : // No clobber
+    );
+
+    return reg0;
 #else
     #error "No igloo_hypercall2 support for architecture"
-    return 0;
 #endif
 }

--- a/package.sh
+++ b/package.sh
@@ -39,5 +39,10 @@ mv nvram.o $SCRATCH/nvram.o.mips64eb
 mv libnvram.so $SCRATCH/libnvram.so.mips64eb
 make clean
 
+CC=x86_64-linux-musl-gcc make CFLAGS="-DCONFIG_X86_64=1" libnvram.so -C /app
+mv nvram.o $SCRATCH/nvram.o.x86_64
+mv libnvram.so $SCRATCH/libnvram.so.x86_64
+make clean
+
 tar -czvf /app/libnvram-latest.tar.gz -C $(dirname $SCRATCH) libnvram
 rm -rf /app/out


### PR DESCRIPTION
Part of https://github.com/rehosting/penguin/issues/135

This also brings hypercall.h to be closer to the implementation present in rehosting/linux. At some point we should have both be pulled from a common source similar to how libhc was. One difficulty for that would be that libnvram expects `CONFIG_AARCH64` and linux expects `CONFIG_ARM64` but this would probably only require a change to `package.sh` to fix for libnvram