### PR TITLE
Disable default shims, perf enhancement for unset keys, disable special noinitrc hack

### DIFF
--- a/mappings.py
+++ b/mappings.py
@@ -1,0 +1,139 @@
+string_introspection = {
+    "strcmp": "libinject_strcmp",
+    "strncmp": "libinject_strncmp",
+    "getenv": "libinject_getenv",
+    "strstr": "libinject_strstr"
+}
+
+
+atheros_broadcom = {
+    "nvram_get_nvramspace": "libinject_nvram_get_nvramspace",
+    "nvram_nget": "libinject_nvram_nget",
+    "nvram_nset": "libinject_nvram_nset",
+    "nvram_nset_int": "libinject_nvram_nset_int",
+    "nvram_nmatch": "libinject_nvram_nmatch"
+}
+
+realtek = {
+    "apmib_get": "libinject_apmib_get",
+    "apmib_set": "libinject_apmib_set"
+}
+
+netgear_acos = {
+    "WAN_ith_CONFIG_GET": "libinject_WAN_ith_CONFIG_GET"
+}
+
+zyxel_or_edimax = {
+    "nvram_getall_adv": "libinject_nvram_getall_adv",
+    "nvram_get_adv": "libinject_nvram_get_adv",
+    "nvram_set_adv": "libinject_nvram_set_adv",
+    "nvram_state": "libinject_nvram_state",
+    "envram_commit": "libinject_envram_commit",
+    "envram_default": "libinject_envram_default",
+    "envram_load": "libinject_envram_load",
+    "envram_safe_load": "libinject_envram_safe_load",
+    "envram_match": "libinject_envram_match",
+    "envram_get": "libinject_envram_get",
+    "envram_getf": "libinject_envram_getf",
+    "envram_set": "libinject_envram_set",
+    "envram_setf": "libinject_envram_setf",
+    "envram_unset": "libinject_envram_unset"
+}
+
+ralink = {
+    "nvram_bufget": "libinject_nvram_bufget",
+    "nvram_bufset": "libinject_nvram_bufset"
+}
+
+
+# One to one mappings of orig fn to shim
+base_names = {
+    "nvram_init": "libinject_nvram_init",
+    "nvram_reset": "libinject_nvram_reset",
+    "nvram_clear": "libinject_nvram_clear",
+    "nvram_close": "libinject_nvram_close",
+    "nvram_commit": "libinject_nvram_commit",
+    "nvram_get": "libinject_nvram_get",
+    "nvram_safe_get": "libinject_nvram_safe_get",
+    "nvram_default_get": "libinject_nvram_default_get",
+    "nvram_get_buf": "libinject_nvram_get_buf",
+    "nvram_get_int": "libinject_nvram_get_int",
+    "nvram_getall": "libinject_nvram_getall",
+    "nvram_set": "libinject_nvram_set",
+    "nvram_set_int": "libinject_nvram_set_int",
+    "nvram_unset": "libinject_nvram_unset",
+    "nvram_safe_unset": "libinject_nvram_safe_unset",
+    "nvram_list_add": "libinject_nvram_list_add",
+    "nvram_list_exist": "libinject_nvram_list_exist",
+    "nvram_list_del": "libinject_nvram_list_del",
+    "nvram_match": "libinject_nvram_match",
+    "nvram_invmatch": "libinject_nvram_invmatch",
+    "nvram_parse_nvram_from_file": "libinject_parse_nvram_from_file",
+}
+
+# Alternative names for the same function
+base_aliases = {
+    "nvram_load": "libinject_nvram_init",
+    "nvram_loaddefault": "libinject_ret_1",
+    "_nvram_get": "libinject_nvram_get",
+    "nvram_get_state": "libinject_nvram_get_int",
+    "nvram_set_state": "libinject_nvram_set_int",
+    "nvram_restore_default": "libinject_nvram_reset",
+    "nvram_upgrade": "libinject_nvram_commit",
+    "get_default_mac": "libinject_ret_1",
+    "VCTGetPortAutoNegSetting": "libinject_ret_0_arg",
+    "agApi_fwGetFirstTriggerConf": "libinject_ret_1_arg",
+    "agApi_fwGetNextTriggerConf": "libinject_ret_1_arg",
+    "artblock_get": "libinject_nvram_get",
+    "artblock_fast_get": "libinject_nvram_safe_get",
+    "artblock_safe_get": "libinject_nvram_safe_get",
+    "artblock_set": "libinject_nvram_set",
+    "nvram_flag_set": "libinject_ret_1",
+    "nvram_flag_reset": "libinject_ret_1",
+    "nvram_master_init": "libinject_ret_0",
+    "nvram_slave_init": "libinject_ret_0",
+    "apmib_init": "libinject_ret_1",
+    "apmib_reinit": "libinject_ret_1",
+    "apmib_update": "libinject_ret_1",
+    "WAN_ith_CONFIG_SET_AS_STR": "libinject_nvram_nset",
+    "WAN_ith_CONFIG_SET_AS_INT": "libinject_nvram_nset_int",
+    "acos_nvram_init": "libinject_nvram_init",
+    "acos_nvram_get": "libinject_nvram_get",
+    "acos_nvram_read": "libinject_nvram_get_buf",
+    "acos_nvram_set": "libinject_nvram_set",
+    "acos_nvram_loaddefault": "libinject_ret_1",
+    "acos_nvram_unset": "libinject_nvram_unset",
+    "acos_nvram_commit": "libinject_nvram_commit",
+    "acosNvramConfig_init": "libinject_nvram_init",
+    "acosNvramConfig_get": "libinject_nvram_get",
+    "acosNvramConfig_read": "libinject_nvram_get_buf",
+    "acosNvramConfig_set": "libinject_nvram_set",
+    "acosNvramConfig_write": "libinject_nvram_set",
+    "acosNvramConfig_unset": "libinject_nvram_unset",
+    "acosNvramConfig_match": "libinject_nvram_match",
+    "acosNvramConfig_invmatch": "libinject_nvram_invmatch",
+    "acosNvramConfig_save": "libinject_nvram_commit",
+    "acosNvramConfig_save_config": "libinject_nvram_commit",
+    "acosNvramConfig_loadFactoryDefault": "libinject_ret_1",
+    "nvram_commit_adv": "libinject_nvram_commit",
+    "nvram_unlock_adv": "libinject_ret_1",
+    "nvram_lock_adv": "libinject_ret_1",
+    "nvram_check": "libinject_ret_1",
+    "envram_get_func": "libinject_envram_get",
+    "nvram_getf": "libinject_envram_getf",
+    "envram_set_func": "libinject_envram_set",
+    "nvram_setf": "libinject_envram_setf",
+    "envram_unset_func": "libinject_envram_unset",
+}
+
+# All variables together
+default_lib_aliases = {
+    string_introspection,
+    atheros_broadcom,
+    realtek,
+    netgear_acos,
+    zyxel_or_edimax,
+    ralink,
+    base_names,
+    base_aliases
+}

--- a/nvram.c
+++ b/nvram.c
@@ -399,7 +399,7 @@ int libinject_nvram_get_buf(const char *key, char *buf, size_t sz) {
     }
     else
     {
-        PRINT_MSG("\n\n[NVRAM] %d %s\n\n", strlen(key), key);
+        PRINT_MSG("\n\n[NVRAM] %d %s\n\n", (int)strlen(key), key);
 
         // success
         rv = igloo_hypercall2(108, (unsigned long)path, strlen(path));
@@ -726,7 +726,13 @@ int libinject_parse_nvram_from_file(const char *file)
 
     /* Allocate memory */
     buffer = (char*)malloc(sizeof(char) *fileLen);
-    fread(buffer, 1, fileLen, f);
+    int rv = fread(buffer, 1, fileLen, f);
+    if (rv != fileLen) {
+        PRINT_MSG("Unable to read file: %s: %d!\n", file, rv);
+        free(buffer);
+        fclose(f);
+        return E_FAILURE;
+    }
     fclose(f);
 
     /* split the buffer including null byte */

--- a/nvram.c
+++ b/nvram.c
@@ -293,8 +293,8 @@ int nvram_get_buf(const char *key, char *buf, size_t sz) {
 
 #ifdef FIRMAE_NVRAM
             //If key value is not found, make the default value to ""
-            if (!strcmp(key, "noinitrc")) // Weird magic constant from FirmAE
-                return E_FAILURE;
+            //if (!strcmp(key, "noinitrc")) // Weird magic constant from FirmAE
+            //    return E_FAILURE;
             strcpy(buf,"");
             return E_SUCCESS;
 #else

--- a/nvram.c
+++ b/nvram.c
@@ -30,7 +30,7 @@
 /* Global variables */
 static int init = 0;
 static char temp[BUFFER_SIZE];
-static int firmae_nvram = 1;
+#define FIRMAE_NVRAM 1
 
 static int dir_lock() {
     int dirfd;
@@ -267,10 +267,11 @@ int nvram_get_buf(const char *key, char *buf, size_t sz) {
 
     if (!key) {
         PRINT_MSG("NULL input key, buffer: %s!\n", buf);
-        if (firmae_nvram)
+#ifdef FIRMAE_NVRAM
             return E_SUCCESS;
-        else
+#else
             return E_FAILURE;
+#endif
     }
 
     PRINT_MSG("%s\n", key);
@@ -290,16 +291,16 @@ int nvram_get_buf(const char *key, char *buf, size_t sz) {
         }
 
 
-        if (firmae_nvram)
-        {
+#ifdef FIRMAE_NVRAM
             //If key value is not found, make the default value to ""
             if (!strcmp(key, "noinitrc")) // Weird magic constant from FirmAE
                 return E_FAILURE;
             strcpy(buf,"");
             return E_SUCCESS;
-        }
-        else
+#else
             return E_FAILURE;
+#endif
+
     }
     else
     {

--- a/nvram.h
+++ b/nvram.h
@@ -1,103 +1,115 @@
 #ifndef INCLUDE_NVRAM_H
 #define INCLUDE_NVRAM_H
 
+// We prefix every "exposed" function with `libinject_` as we don't want to clobber
+// anything by default.
+// Internal methods will be prefixed with `_libinject_`.
+
 // Locks the nvram directory. Will block.
-static int dir_lock();
+//static int _libinject_dir_lock();
 // Unlocks the nvram directory.
-static void dir_unlock(int dirfd);
+//static void _libinject_dir_unlock(int dirfd);
 
 /* The following functions form the standard NVRAM API. Functions that return integers
  * will generally return E_SUCCESS/E_FAILURE, with the exception of nvram_get_int(). */
 
 // Initializes NVRAM with default values. Will hold lock.
-int nvram_init(void);
+int libinject_nvram_init(void);
 // Restores original NVRAM default values.
-int nvram_reset(void);
+int libinject_nvram_reset(void);
 // Clears NVRAM values. Will hold lock.
-int nvram_clear(void);
+int libinject_nvram_clear(void);
 // Pretends to close NVRAM, does nothing.
-int nvram_close(void);
+int libinject_nvram_close(void);
 // Pretends to commit NVRAM, actually synchronizes file system.
-int nvram_commit(void);
+int libinject_nvram_commit(void);
 
 // Given a key, gets the corresponding NVRAM value. If key is non-existent, returns NULL.
 // Will dynamically allocate memory, so the user should call free().
 // On MIPS, will use $a1 as key if $a0 is NULL.
-char *nvram_get(const char *key);
+char *libinject_nvram_get(const char *key);
 // Given a key, gets the corresponding NVRAM value. If key is non-existent, returns "".
 // Will dynamically allocate memory.
-char *nvram_safe_get(const char *key);
+char *libinject_nvram_safe_get(const char *key);
 // Given a key, gets the corresponding NVRAM value. If key is non-existent, returns val.
 // Otherwise, returns NULL. Will dynamically allocate memory.
-char *nvram_default_get(const char *key, const char *val);
+char *libinject_nvram_default_get(const char *key, const char *val);
 // Given a key, gets the corresponding NVRAM value into a user-supplied buffer.
 // Will hold lock.
-int nvram_get_buf(const char *key, char *buf, size_t sz);
+int libinject_nvram_get_buf(const char *key, char *buf, size_t sz);
 // Given a key, gets the corresponding NVRAM value as integer. If key is non-existent, returns E_FAILURE.
 // Will hold lock.
-int nvram_get_int(const char *key);
+int libinject_nvram_get_int(const char *key);
 // Gets all NVRAM keys and values into a user-supplied buffer, of the format "key=value...".
 // Will hold lock.
-int nvram_getall(char *buf, size_t len);
+int libinject_nvram_getall(char *buf, size_t len);
 
 // Given a key and value, sets the corresponding NVRAM value. Will hold lock.
-int nvram_set(const char *key, const char *val);
+int libinject_nvram_set(const char *key, const char *val);
 // Given a key and value as integer, sets the corresponding NVRAM value. Will hold lock.
-int nvram_set_int(const char *key, const int val);
+int libinject_nvram_set_int(const char *key, const int val);
 // Given a key, unsets the corresponding NVRAM value. Will hold lock.
-int nvram_unset(const char *key);
+int libinject_nvram_unset(const char *key);
 // Given a key, unset the corresponding NVRAM value if it is set. Will hold lock if it's set
-int nvram_safe_unset(const char *key);
-// Reloads default NVRAM values.
-int nvram_set_default(void);
+int libinject_nvram_safe_unset(const char *key);
+
+// Reloads default NVRAM values. XXX: unused in libinject as we initialize differently
+//int libinject_nvram_set_default(void);
 
 // Adds a list entry to a NVRAM value.
-int nvram_list_add(const char *key, const char *val);
+int libinject_nvram_list_add(const char *key, const char *val);
 // Checks whether a list entry exists in a NVRAM value. If the magic argument
 // is equal to LIST_MAGIC, will either return a pointer to the match or NULL.
-char *nvram_list_exist(const char *key, const char *val, int magic);
+char *libinject_nvram_list_exist(const char *key, const char *val, int magic);
 // Deletes a list entry from a NVRAM value.
-int nvram_list_del(const char *key, const char *val);
+int libinject_nvram_list_del(const char *key, const char *val);
 
 // Given a key, checks whether the corresponding NVRAM value matches val.
-int nvram_match(const char *key, const char *val);
+int libinject_nvram_match(const char *key, const char *val);
 // Given a key, checks whether the corresponding NVRAM value does not match val.
-int nvram_invmatch(const char *key, const char *val);
+int libinject_nvram_invmatch(const char *key, const char *val);
 
 // Parse a default nvram including null byte and passing key,val to nvram_set(JR6150)
-int parse_nvram_from_file(const char *file);
+int libinject_parse_nvram_from_file(const char *file);
+
+/* Atheros/Broadcom NVRAM */
+int libinject_nvram_get_nvramspace(void);
+char *libinject_nvram_nget(const char *fmt, ...);
+int libinject_nvram_nset(const char *val, const char *fmt, ...);
+int libinject_nvram_nset_int(const int val, const char *fmt, ...);
+int libinject_nvram_nmatch(const char *val, const char *fmt, ...);
+
+/* Realtek */
+int libinject_apmib_get(const int key, void *buf);
+int libinject_apmib_set(const int key, void *buf);
+
+/* Netgear ACOS */
+int libinject_WAN_ith_CONFIG_GET(char *buf, const char *fmt, ...);
+
+/* ZyXel / Edimax */
+int libinject_nvram_getall_adv(int unk, char *buf, size_t len);
+char *libinject_nvram_get_adv(int unk, const char *key);
+int libinject_nvram_set_adv(int unk, const char *key, const char *val);
+int libinject_nvram_state(int unk1, void *unk2, void *unk3);
+int libinject_envram_commit(void);
+int libinject_envram_default(void);
+int libinject_envram_load(void);
+int libinject_envram_safe_load(void);
+int libinject_envram_match(const char *key, const char *val);
+int libinject_envram_get(const char* key, char *buf);
+int libinject_envram_getf(const char* key, const char *fmt, ...);
+int libinject_envram_set(const char *key, const char *val);
+int libinject_envram_setf(const char* key, const char* fmt, ...);
+int libinject_envram_unset(const char *key);
+
+/* Ralink */
+char *libinject_nvram_bufget(int idx, const char *key);
+int libinject_nvram_bufset(int idx, const char *key, const char *val);
 
 // Base functions
-int true();
-int false();
-int true1(char* a1);
-int false1(char* a1);
+int libinject_ret_true();
+int libinject_ret_false();
+int libinject_ret_true1(char* a1);
+int libinject_ret_false1(char* a1);
 
-int flock_asm(int fd, int op) {
-    int retval;
-#if defined(__mips__)
-    asm volatile(
-    "move $a0, %1\n"        // Correctly move fd (from C variable) to $a0
-    "move $a1, %2\n"        // Correctly move op (from C variable) to $a1
-    "li $v0, %3\n"          // Load the syscall number for flock into $v0
-    "syscall\n"             // Perform the syscall
-    "move %0, $v0"          // Move the result from $v0 to retval
-    : "=r" (retval)         // Output
-    : "r" (fd), "r" (op), "i" (SYS_flock) // Inputs; "i" for immediate syscall number
-    : "v0", "a0", "a1"      // Clobber list
-);
-#elif defined(__arm__)
-    asm volatile(
-    "mov r0, %1\n"  // Move fd to r0, the first argument for the system call
-    "mov r1, %2\n"  // Move op to r1, the second argument for the system call
-    "mov r7, %3\n"  // Move SYS_flock (the system call number) to r7
-    "svc 0x00000000\n"  // Make the system call
-    "mov %[result], r0"  // Move the result from r0 to retval
-    : [result]"=r" (retval)  // Output
-    : "r"(fd), "r"(op), "i"(SYS_flock)  // Inputs
-    : "r0", "r1", "r7"  // Clobber list
-);
-#endif
-    return retval;
-}
 #endif

--- a/strings.h
+++ b/strings.h
@@ -4,16 +4,34 @@
 #include "hypercall.h"
 #include <stddef.h>
 
-#define PAGE_IN(s) igloo_page_in_str((volatile const char *)(s))
+#define PAGE_IN(s) _libinject_page_in_str((volatile const char *)(s))
 
 #define TARGET_VALUE "DYNVALDYNVALDYNVAL"
 extern char **environ;
 
-void igloo_page_in_str(volatile const char *s);
-size_t minimal_strlen(const char *s);
-int minimal_strncmp(short do_log, size_t n, const char *s1, const char *s2);
-int minimal_strcmp(const char *s1, const char *s2, short do_log);
-char *minimal_getenv(const char *name);
-char *getenv(const char *name);
+// Internal data types
+typedef enum {
+    STRCMP,
+    STRNCMP,
+    GETENV
+} source;
+typedef struct {
+    source source;
+    const char* value;
+} match;
+
+// Internal methods
+void _libinject_log_match(match m);
+void _libinject_page_in_str(volatile const char *s);
+size_t _libinject_minimal_strlen(const char *s);
+int _libinject_minimal_strncmp(short do_log, size_t n, const char *s1, const char *s2);
+int _libinject_minimal_strcmp(const char *s1, const char *s2, short do_log);
+char *_libinject_minimal_getenv(const char *name);
+
+// External methods: getenv and strstr
+int libinject_strcmp(const char *s1, const char *s2);
+int libinject_strncmp(const char *s1, const char *s2, size_t n);
+char *libinject_getenv(const char *name);
+char *libinject_strstr(const char *haystack, const char *needle);
 
 #endif


### PR DESCRIPTION
* Improve performance: change the `firmae_nvram` variable to a preprocessor variable since it's always set and make a fail-fast path for accesses to unset keys (don't waste time with locks if key is unset).
* Disable a special case for calls to nvram_get for a key 'noinitrc' - if we want to do this let's place it somewhere else (e.g., as a default in our nvram values with an empty string)
* Fix a bug where `flock_asm` wasn't doing anything for architectures other than arm32/mips32 🤯 this might have been breaking some rehostings in the past
* Prefix all functions with `libinject_`.


Last point is most important, it allows us to dynamically enable/disable these shims with our aliases. **But this is backwards incompatible** as prior configs wouldn't contain the defaults in their aliases.