### PR TITLE
add missing hypercall on nvram_get failures

### DIFF
--- a/nvram.c
+++ b/nvram.c
@@ -362,6 +362,7 @@ int libinject_nvram_get_buf(const char *key, char *buf, size_t sz) {
 
     // Before taking the lock, check if the key exists, if not bail
     if (access(path, F_OK) != 0) {
+        rv = igloo_hypercall2(107, (unsigned long)path, strlen(path));
 #ifdef FIRMAE_NVRAM
         // Key doesn't exist, set default empty value
         buf[0] = '\0';


### PR DESCRIPTION
The PR causes us to report `nvram_get` failures when the underlying key doesn't exist.