### PR TITLE
Fixup

### DIFF
--- a/config.h
+++ b/config.h
@@ -4,7 +4,7 @@
 // Determines whether debugging information should be printed to stderr.
 #define DEBUG               0
 // Determines the size of the internal buffer, used for manipulating and storing key values, etc.
-#define BUFFER_SIZE         256
+#define BUFFER_SIZE         1024
 // Determines the size of the "emulated" NVRAM, used by nvram_get_nvramspace().
 #define NVRAM_SIZE          2048
 // Determines the maximum size of the user-supplied output buffer when a length is not supplied.

--- a/config.h
+++ b/config.h
@@ -4,7 +4,7 @@
 // Determines whether debugging information should be printed to stderr.
 #define DEBUG               0
 // Determines the size of the internal buffer, used for manipulating and storing key values, etc.
-#define BUFFER_SIZE         1024
+#define BUFFER_SIZE         4096
 // Determines the size of the "emulated" NVRAM, used by nvram_get_nvramspace().
 #define NVRAM_SIZE          2048
 // Determines the maximum size of the user-supplied output buffer when a length is not supplied.

--- a/nvram.c
+++ b/nvram.c
@@ -391,7 +391,7 @@ int libinject_nvram_get_buf(const char *key, char *buf, size_t sz) {
 
     PRINT_MSG("%s\n", key);
 
-    strncat(path, key, ARRAY_SIZE(path) - ARRAY_SIZE(MOUNT_POINT) - 1);
+    strncat(path, key, sizeof(path) - strlen(path) - 1);
 
     // Before taking the lock, check if the key exists, if not bail
     if (access(path, F_OK) != 0) {
@@ -471,7 +471,7 @@ int libinject_nvram_get_int(const char *key) {
 
     PRINT_MSG("%s\n", key);
 
-    strncat(path, key, ARRAY_SIZE(path) - ARRAY_SIZE(MOUNT_POINT) - 1);
+    strncat(path, key, sizeof(path) - strlen(path) - 1);
 
     // Before taking the lock, check if the key exists, if not bail
     if (access(path, F_OK) != 0) {
@@ -600,7 +600,7 @@ int libinject_nvram_set(const char *key, const char *val) {
 
     PRINT_MSG("%s = \"%s\"\n", key, val);
 
-    strncat(path, key, ARRAY_SIZE(path) - ARRAY_SIZE(MOUNT_POINT) - 1);
+    strncat(path, key, sizeof(path) - strlen(path) - 1);
 
     rv = igloo_hypercall2(109, (unsigned long)path, (unsigned long)val);
     while (rv == 1) {
@@ -641,7 +641,7 @@ int libinject_nvram_set_int(const char *key, const int val) {
 
     PRINT_MSG("%s = %d\n", key, val);
 
-    strncat(path, key, ARRAY_SIZE(path) - ARRAY_SIZE(MOUNT_POINT) - 1);
+    strncat(path, key, sizeof(path) - strlen(path) - 1);
 
     dirfd = _libinject_dir_lock();
 
@@ -675,7 +675,7 @@ int libinject_nvram_unset(const char *key) {
 
     PRINT_MSG("%s\n", key);
 
-    strncat(path, key, ARRAY_SIZE(path) - ARRAY_SIZE(MOUNT_POINT) - 1);
+    strncat(path, key, sizeof(path) - strlen(path) - 1);
 
     rv = igloo_hypercall2(110, (unsigned long)path, strlen(path));
     while (rv == 1) {

--- a/nvram.c
+++ b/nvram.c
@@ -630,7 +630,7 @@ int libinject_nvram_set(const char *key, const char *val) {
 }
 
 int libinject_nvram_set_int(const char *key, const int val) {
-    char path[PATH_MAX] = MOUNT_POINT;
+    char path[PATH_MAX];
     FILE *f;
     int dirfd;
 
@@ -638,10 +638,17 @@ int libinject_nvram_set_int(const char *key, const int val) {
         PRINT_MSG("%s\n", "NULL key!");
         return E_FAILURE;
     }
+    // Truncate key if too long
+    size_t max_key_len = PATH_MAX - strlen(MOUNT_POINT) - 1;
+    char truncated_key[PATH_MAX];
+    strncpy(truncated_key, key, max_key_len);
+    truncated_key[max_key_len] = '\0';
 
-    PRINT_MSG("%s = %d\n", key, val);
+    PRINT_MSG("%s = %d\n", truncated_key, val);
 
-    strncat(path, key, sizeof(path) - strlen(path) - 1);
+    // Use snprintf for safe path construction
+    snprintf(path, sizeof(path), "%s%s", MOUNT_POINT, truncated_key);
+    path[PATH_MAX - 1] = '\0'; // Ensure null-termination
 
     dirfd = _libinject_dir_lock();
 
@@ -672,10 +679,17 @@ int libinject_nvram_unset(const char *key) {
         PRINT_MSG("%s\n", "NULL key!");
         return E_FAILURE;
     }
+    // Truncate key if too long
+    size_t max_key_len = PATH_MAX - strlen(MOUNT_POINT) - 1;
+    char truncated_key[PATH_MAX];
+    strncpy(truncated_key, key, max_key_len);
+    truncated_key[max_key_len] = '\0';
 
-    PRINT_MSG("%s\n", key);
+    PRINT_MSG("%s\n", truncated_key);
 
-    strncat(path, key, sizeof(path) - strlen(path) - 1);
+    // Use snprintf for safe path construction
+    snprintf(path, sizeof(path), "%s%s", MOUNT_POINT, truncated_key);
+    path[PATH_MAX - 1] = '\0'; // Ensure null-termination
 
     rv = igloo_hypercall2(110, (unsigned long)path, strlen(path));
     while (rv == 1) {


### PR DESCRIPTION
This PR adds better checks around nvram functions. Further, it increases the potential buffer size and uses malloc to allocate buffers instead.

Supersedes: #25 